### PR TITLE
Fix typo in`decode_as_ast` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ service "http" {
 }
 """
 
-{:ok %HXL.Body{}} = HXL.decode_as_ast(hcl)
+{:ok, %HXL.Body{}} = HXL.decode_as_ast(hcl)
 
 ```
 


### PR DESCRIPTION
Quick fix for a small typo I found in the README.